### PR TITLE
First version of data cleaning

### DIFF
--- a/redpy/config.py
+++ b/redpy/config.py
@@ -3,8 +3,8 @@ class Options(object):
     def __init__(self, title="REDPy Catalog", filename="redtable.h5", groupName="hsr",
         groupDesc="MSH: HSR-EHZ-UW Default", station="HSR", channel="EHZ", network="UW",
         location="--", samprate=100.0, lwin=7.0, swin=0.8, trigon=3.0, trigoff=2.0,
-        mintrig=10.0, winlen=512, ptrig=10.0, atrig=20.0, fhigh=0.25, fmin=1.0,
-        fmax=10.0, cmin=0.7):
+        mintrig=10.0, kurtmax=80., kurtfmax=150., oratiomax=0.06, kurtwin=5., winlen=512,
+        ptrig=10.0, atrig=20.0, fhigh=0.25, fmin=1., fmax=10.0, cmin=0.7):
         
         """
         Defines the settings that are often passed to routines and that define the table.
@@ -29,6 +29,11 @@ class Options(object):
         trigon: Cutoff ratio for triggering STALTA (default 3.0)
         trigoff: Cutoff ratio for ending STALTA trigger (default 2.0)
         mintrig: Minimum spacing between triggers (default 10.0 s)
+        kurtmax: Maximum kurtosis allowed for event window, to eliminate spikes (default 80) ~80-100 is appropriate for 5s window, ~130 for 15s, ~200 for 25s
+        kurtfmax: Maximum kurtosis of frequency amplitude spectrum (default 150) to eliminate calibration pulses with unnaturally harmonic signals, be careful not to set too low or you could eliminate real harmonic events
+        kurtwin: Length of window to use for kurtosis, in seconds, around the trigger time, will be centered on the trigger time (default 5s)
+        oratiomax: Maximum ratio of outliers to total number of datapoints in trace (default 0.06, 6%)
+
     
         WINDOWING PARAMETERS:
         winlen: Length of window for cross-correlation (default 512 samples, 2^n is best)
@@ -61,6 +66,10 @@ class Options(object):
         self.trigon = trigon
         self.trigoff = trigoff
         self.mintrig = mintrig
+        self.kurtmax = kurtmax
+        self.kurtfmax = kurtfmax
+        self.oratiomax = oratiomax
+        self.kurtwin = kurtwin
         self.winlen = 512         # NOTE: These are all currently hardcoded until we
         self.ptrig = 10.0         # figure out how to not have redpy.table.Trigger and
         self.atrig = 20.0         # redpy.table.Correlation not hardcoded
@@ -68,4 +77,3 @@ class Options(object):
         self.fmin = fmin
         self.fmax = fmax
         self.cmin = cmin
-        

--- a/redpy/plotting.py
+++ b/redpy/plotting.py
@@ -47,3 +47,18 @@ def createCMatrixFigure(rtable, ctable):
     ax = fig.add_subplot(1, 2, 2)
     ax.imshow(Co, aspect='auto', vmin=0.65, vmax=1, interpolation='nearest')
 
+def createWigglePlot(jtable,opt):
+    #waveform wiggle plot of input waveforms
+    fig = plt.figure(figsize=(20, 15))
+    n=0.
+    for r in jtable.iterrows():
+        dat=r['waveform']
+        dat=dat/max(dat)
+        tvec = np.arange(0,len(dat)*1/opt.samprate,1/opt.samprate)
+        plt.plot(tvec,np.add(dat,n))
+        n = n+3
+    plt.ylabel('index')
+    plt.xlabel('time(s)')
+    #plt.title('Junk triggers')
+    plt.autoscale(tight=True)
+    plt.show()

--- a/scaletest.py
+++ b/scaletest.py
@@ -22,10 +22,11 @@ h5file = open_file(opt.filename, "a")
 rtable = eval('h5file.root.'+ opt.groupName + '.repeaters')
 otable = eval('h5file.root.'+ opt.groupName + '.orphans')
 ctable = eval('h5file.root.'+ opt.groupName + '.correlation')
+jtable = eval('h5file.root.'+ opt.groupName + '.junk')
 
 ttimer = time.time()
-tstart = UTCDateTime('2014-08-08')
-nhour = int(6.5*24)
+tstart = UTCDateTime('2014-08-12')
+nhour = int(1*24)
 
 previd = 0
 for hour in range(nhour):
@@ -33,8 +34,14 @@ for hour in range(nhour):
     t = tstart+hour*3600
     print(t)
     st = redpy.trigger.getIRIS(t, opt, nsec=3600)
-    trigs = redpy.trigger.trigger(st, opt)
-    
+    alltrigs = redpy.trigger.trigger(st, opt)
+    # Clean out data spikes etc.
+    trigs, junk = redpy.trigger.dataclean(alltrigs,opt,flag=1)
+
+    #save junk triggers in separate table for quality checking purposes
+    for i in range(len(junk)):
+        redpy.table.populateJunk(jtable,junk[i],0,opt)
+
     if len(trigs) > 0:
         
         ostart = 0
@@ -49,6 +56,8 @@ for hour in range(nhour):
             redpy.correlation.runCorrelation(rtable, otable, ctable, trigs[i], id, opt)
         previd = id + 1
 
+
+
 print("Correlation done in: {:03.2f} seconds".format(time.time()-ttimer))
 
 # Run clustering one more time before plotting
@@ -62,11 +71,13 @@ print("Number of clusters: {0}".format(max(rtable.cols.clusterNumber[:])))
 # May need to alter code to better deal with these guys, currently if there is a leftover,
 # it is likely to never be re-associated with a family again...
 print("Number of leftovers in clustering: {0}".format(len(rtable.get_where_list('clusterNumber == -1'))))
+print("Number of junk triggers: {0}".format(len(jtable)))
 
 # Plot ordered waveforms and correlation matrix (unordered and ordered)
 redpy.plotting.createOrderedWaveformFigure(rtable)
 redpy.plotting.createCMatrixFigure(rtable, ctable)
-
+# Plot junk events
+redpy.plotting.createWigglePlot(jtable, opt)
 plt.show()
 
 h5file.close()


### PR DESCRIPTION
I added a def to redpy.trigger that cleans spikes by computing kurtosis in a window around the trigger time, cleans calibration pulses by computing kurtosis of the fft and seeing if the fft is too spiked, and to clean square waves by computing the ratio of outlier samples to all samples. Events that are classified as junk are stored in a new Junk table (jtable). Also added a way to plot the junk events in redpy.plotting that is run in scaletest.py
