### PR TITLE
Adds options for STA/LTA algorithm

### DIFF
--- a/redpy/config.py
+++ b/redpy/config.py
@@ -62,6 +62,7 @@ class Options(object):
             of samples that will be cut based on ptrig and atrig
                 
         TRIGGERING PARAMETERS:
+        trigalg: Trigger algorithm to be used for STALTA (default 'classicstalta')
         lwin: Length of long window for STALTA (default 7.0 s)
         swin: Length of short window for STALTA (default 0.8 s)
         trigon: Cutoff ratio for triggering STALTA (default 3.0)
@@ -170,6 +171,8 @@ class Options(object):
             'Settings','filepattern') else '*'
         self.nsec=config.getint('Settings','nsec') if config.has_option(
             'Settings','nsec') else 3600
+        self.trigalg=config.get('Settings','trigalg') if config.has_option(
+            'Settings','trigalg') else 'classicstalta'
         self.lwin=config.getfloat('Settings','lwin') if config.has_option(
             'Settings','lwin') else 7.
         self.swin=config.getfloat('Settings','swin') if config.has_option(

--- a/redpy/trigger.py
+++ b/redpy/trigger.py
@@ -174,7 +174,7 @@ def trigger(st, stC, rtable, opt):
     tr = st[0]
     t = tr.stats.starttime
 
-    cft = coincidence_trigger("classicstalta", opt.trigon, opt.trigoff, stC, opt.nstaC,
+    cft = coincidence_trigger(opt.trigalg, opt.trigon, opt.trigoff, stC, opt.nstaC,
         sta=opt.swin, lta=opt.lwin, details=True)
             
     if len(cft) > 0:

--- a/settings.cfg
+++ b/settings.cfg
@@ -73,6 +73,16 @@ filepattern=*
 
 ###### TRIGGERING SETTINGS ######
 
+# Choose the STALTA algorithm. Options include a selection of trigger algorithms
+# supported by ObsPy's network coincidence trigger (suggested values for 'lwin' and 'swin'
+# are in parentheses, followed by suggested values for 'trigon' and 'trigoff'):
+# * 'classicstalta' : Classic STA/LTA   (8., 0.7),  (3., 2.)
+# * 'recstalta'     : Recursive STA/LTA (3., 8.),  (2., 1.5)
+# * 'delayedstalta' : Delayed STA/LTA   (5., 10.),  (5., 10,)   
+# For more details, please visit:
+#  https://docs.obspy.org/packages/autogen/obspy.core.trace.Trace.trigger.html#obspy.core.trace.Trace.trigger
+#  and https://docs.obspy.org/tutorial/code_snippets/trigger_tutorial.html
+trigalg=classicstalta
 # How many stations need to be triggered in order to be considered using a coincidence
 # trigger? I like using just over half of nsta. Using less allows more triggers through,
 # but that may not be real events or are of dubious quality. Requiring all stations to


### PR DESCRIPTION
Here's some small changes to allow the STA/LTA algorithm to be defined.

Only Classic, Recursive, and Delayed are allowed at this time. ObsPy's other options (Z-Detect and Carl-Sta-Trig) require slightly different input parameters, so I didn't implement them.

Attached are the files associated with a trial run I did on the St. Helen's data
>>> python backfill.py -v -c settings-recstalta.cfg -s 2004-09-15 -e 2004-09-24
[recstalta_test.zip](https://github.com/ahotovec/REDPy/files/3744693/recstalta_test.zip)
