### PR TITLE
replace Winston gap values

### DIFF
--- a/redpy/trigger.py
+++ b/redpy/trigger.py
@@ -112,7 +112,6 @@ def getData(tstart, tend, opt):
             try:
                 stmp = client.get_waveforms(nets[n], stas[n], locs[n], chas[n],
                         tstart, tend+opt.maxdt)
-                print(stmp)
                 for m in range(len(stmp)):
                     stmp[m].data = np.where(stmp[m].data == -2**31, 0, stmp[m].data) # replace -2**31 (Winston NaN token) w 0
                 stmp.merge()

--- a/redpy/trigger.py
+++ b/redpy/trigger.py
@@ -114,7 +114,6 @@ def getData(tstart, tend, opt):
                         tstart, tend+opt.maxdt)
                 for m in range(len(stmp)):
                     stmp[m].data = np.where(stmp[m].data == -2**31, 0, stmp[m].data) # replace -2**31 (Winston NaN token) w 0
-                stmp.merge()
                 stmp = stmp.filter('bandpass', freqmin=opt.fmin, freqmax=opt.fmax,
                     corners=2, zerophase=True)
                 stmp = stmp.taper(0.05,type='hann',max_length=opt.mintrig)
@@ -128,7 +127,6 @@ def getData(tstart, tend, opt):
                             tstart, tend+opt.maxdt)
                     for m in range(len(stmp)):
                         stmp[m].data = np.where(stmp[m].data == -2**31, 0, stmp[m].data) # replace -2**31 (Winston NaN token) w 0
-                    stmp.merge()
                     stmp = stmp.filter('bandpass', freqmin=opt.fmin, freqmax=opt.fmax,
                         corners=2, zerophase=True)
                     stmp = stmp.taper(0.05,type='hann',max_length=opt.mintrig)

--- a/redpy/trigger.py
+++ b/redpy/trigger.py
@@ -112,6 +112,10 @@ def getData(tstart, tend, opt):
             try:
                 stmp = client.get_waveforms(nets[n], stas[n], locs[n], chas[n],
                         tstart, tend+opt.maxdt)
+                print(stmp)
+                for m in range(len(stmp)):
+                    stmp[m].data = np.where(stmp[m].data == -2**31, 0, stmp[m].data) # replace -2**31 (Winston NaN token) w 0
+                stmp.merge()
                 stmp = stmp.filter('bandpass', freqmin=opt.fmin, freqmax=opt.fmax,
                     corners=2, zerophase=True)
                 stmp = stmp.taper(0.05,type='hann',max_length=opt.mintrig)
@@ -123,6 +127,9 @@ def getData(tstart, tend, opt):
                 try: # try again
                     stmp = client.get_waveforms(nets[n], stas[n], locs[n], chas[n],
                             tstart, tend+opt.maxdt)
+                    for m in range(len(stmp)):
+                        stmp[m].data = np.where(stmp[m].data == -2**31, 0, stmp[m].data) # replace -2**31 (Winston NaN token) w 0
+                    stmp.merge()
                     stmp = stmp.filter('bandpass', freqmin=opt.fmin, freqmax=opt.fmax,
                         corners=2, zerophase=True)
                     stmp = stmp.taper(0.05,type='hann',max_length=opt.mintrig)


### PR DESCRIPTION
Hey Alicia,

I've spent way too much time on this, so I'm just throwing it to you to see what you think. I'm trying to accomplish the task of replacing all of Winston's -2**31 values with something else. Ideally, the -2**31 values would be replaced with some sort of linear interpolation (in case the trace isn't centered around 0), but that turned out to be more involved than I thought. In the interim, I've settled for just replacing everything with 0s. It has to be done on each trace, and it has to happen immediately after the data are retrieved.

In order to do the linear interpolation, something like this would have to be implemented:

for each trace:
.....if trace contains a -2**31 value:
..........trace.data = np.ma.masked_where(trace.data==nan_token, trace.data # first mask the data
..........trace = trace.split().merge(method=0, fill_value='interpolate')[0] # split the data based on the mask and then remerge`

As far as I can tell, the only way to split a trace in obspy is to use masked arrays. But if you try to split a trace with a masked array that doesn't have any masked values, obspy does something weird (thus, the need for the if statement at the beginning). Sooo, it would probably be best to wrap this up in a helper function ("remvove_nan_token" or something like that), but I wasn't sure where to put this in the redpy structure.

Anyway, it's an annoying problem and one that many people probably aren't going to encounter, but it is kind of a pain with the El Salvador data.

Thoughts?