### PR TITLE
Fix typo in redpy/config

### DIFF
--- a/redpy/config.py
+++ b/redpy/config.py
@@ -229,7 +229,7 @@ class Options(object):
             'Settings','dybin') else 1.
         self.hrbin=config.getfloat('Settings','hrbin') if config.has_option(
             'Settings','hrbin') else 1.
-        self.pp=config.getfloat('Settings','occurbin')/24 if config.has_option(   # settings.cfg (hours) immediately converted to days
+        self.occurbin=config.getfloat('Settings','occurbin')/24 if config.has_option(   # settings.cfg (hours) immediately converted to days
             'Settings','occurbin') else 1/24
         self.recbin=config.getfloat('Settings','recbin')/24 if config.has_option( # settings.cfg (hours) immediately converted to days
             'Settings','recbin') else 1/24

--- a/redpy/config.py
+++ b/redpy/config.py
@@ -107,8 +107,8 @@ class Options(object):
         minplot: Minimum number of members required in order to be plotted to timeline
         dybin: Width of bin in days for full histogram (default 1 day)
         hrbin: Width of bin in hours for recent histogram (default 1 hour)
-        occurbin: Width of bin in days for occurrence plot (default 1/24 day)
-        recbin: Width of bin in days for recent occurrence plot (default 1/24 day) 
+        occurbin: Width of bin for occurrence plot; specified in .cfg as hours, converted to days in redpy/config (default 1 hr -> 1/24 day)
+        recbin: Width of bin for recent occurrence; specified in .cfg as hours, converted to days in redpy/config (default 1 hr -> 1/24 day) 
         recplot: Number of days for 'recent' plot (default 14 days)
         plotsta: Station index in station list to be plotted (default 2)
         verbosecatalog: Add additional columns to the catalog file (default False)
@@ -229,9 +229,9 @@ class Options(object):
             'Settings','dybin') else 1.
         self.hrbin=config.getfloat('Settings','hrbin') if config.has_option(
             'Settings','hrbin') else 1.
-        self.occurbin=config.getfloat('Settings','occurbin') if config.has_option(
+        self.pp=config.getfloat('Settings','occurbin')/24 if config.has_option(   # settings.cfg (hours) immediately converted to days
             'Settings','occurbin') else 1/24
-        self.recbin=config.getfloat('Settings','recbin') if config.has_option(
+        self.recbin=config.getfloat('Settings','recbin')/24 if config.has_option( # settings.cfg (hours) immediately converted to days
             'Settings','recbin') else 1/24
         self.recplot=config.getfloat('Settings','recplot') if config.has_option(
             'Settings','recplot') else 14.

--- a/settings.cfg
+++ b/settings.cfg
@@ -135,12 +135,12 @@ minplot=5
 dybin=1
 # Width (in hours) of bins for histogram subplot on 'recent' timeline (default is 1 hour)
 hrbin=1.
-# Width (in days) of bars in occurrence plot (default is 1 hour) - if this is set for
+# Width (in hours) of bars in occurrence plot (default is 1 hour) - if this is set for
 # a day or longer, the color bar will be scaled automatically up to a maximum of 1000
 # events per bin; recommend customizing this setting if your run extends >1 year 
-occurbin=1/24
-# Width (in days) of bars in recent occurrence plot (default is 1 hour)
-recbin=1/24
+occurbin=1
+# Width (in hours) of bars in recent occurrence plot (default is 1 hour)
+recbin=1
 # Number of days prior to last repeater to show on 'recent' timeline (default is 2 weeks)
 recplot=14. 
 # Print a more verbose version of the catalog


### PR DESCRIPTION
Oops, there was a typo in the origin commit. It's fixed here.