### PR TITLE
Fill aligned waveform array with appropriate shape

### DIFF
--- a/redpy/plotting.py
+++ b/redpy/plotting.py
@@ -641,8 +641,9 @@ def plotFamilies(rtable, ftable, ctable, opt):
                         opt.ptrig*opt.samprate)):min(opt.wshape,
                         windowStart[fam[n]]+int(opt.atrig*opt.samprate))]
                     try:
-                        data[n, :] = tmp[int(opt.ptrig*opt.samprate - opt.winlen*0.5):int(
+                        ewarr = tmp[int(opt.ptrig*opt.samprate - opt.winlen*0.5):int(
                             opt.ptrig*opt.samprate + opt.winlen*1.5)]/windowAmp[fam[n]]
+                        data[n, :ewarr.shape[0]] = ewarr
                     except (ValueError, Exception):
                         print('Error in printing family {}, moving on...'.format(cnum))
                 if len(fam) > 12:


### PR DESCRIPTION
Hi @ahotovec, I was using this code to run some waveform analysis and this is a good project. I made some minor changes to resolve the error `Error in printing family 0, moving on...` at the following lines:

https://github.com/ahotovec/REDPy/blob/098495a46acc753a303f22ecf859b646046ea71f/redpy/plotting.py#L644-L645

If array shape between left hand variable and right hand variable differs, it actually throw Numpy exception (but catched at line 646):

    ValueError: could not broadcast input array from shape (...) into shape (...)

For example when `data` array has shape (400, 100) and sliced `tmp` array has shape (98,). Some time it happens when sliced `tmp` array:

```python
tmp[int(opt.ptrig*opt.samprate - opt.winlen*0.5):int(opt.ptrig*opt.samprate + opt.winlen*1.5)]
```
doesn't return equal value (98) with the shape of `data` array column (100). 

In my PR, I just fill `data` array with the value of `tmp` array and left the remaining values with zero if the shape between two array is different. So, it will not throw an exception. Thank you.